### PR TITLE
align Readme code and source code

### DIFF
--- a/Lab6-StepFunction/Lottery-ValidateWinners.py
+++ b/Lab6-StepFunction/Lottery-ValidateWinners.py
@@ -21,11 +21,20 @@ def lambda_handler(event, context):
     
     # if winner is in the past draw, return 0 else return 1
     has_winner_in_queue = 1 if len(output) > 0 else 0
+    
+    # format the winner details in sns
+    winner_names = [winner['employee_name'] for winner in winner_details]
+    
+    name_s = ""
+    for name in winner_names:
+        name_s += name
+        name_s += " "
+    
     return {
         "body": {
             "num_of_winners": num_of_winners,
             "winner_details": winner_details
         },
-        "status": has_winner_in_queue
+        "status": has_winner_in_queue,
+        "sns": "Congrats! [{}] You have selected as the Lucky Champ!".format(name_s.strip())
     }
-        

--- a/Lab6-StepFunction/lottery-sfn.json
+++ b/Lab6-StepFunction/lottery-sfn.json
@@ -96,7 +96,7 @@
              "Resource": "arn:aws:states:::sns:publish",
              "Parameters": {
                "TopicArn": "arn:aws:sns:ap-southeast-1:<account-id>:Lottery-Notification",
-               "Message.$": "$.body"
+               "Message.$": "$.sns"
              },
              "End": true
            }


### PR DESCRIPTION
1. Readme stepfunction defintion and source code lottery-sfn.json is different 
2. Readme Lottery-ValidateWinners.py and source code Lottery-ValidateWinners.py is different

Custom report running failure when he use the Readme stepfunction defintion + source code Lottery-ValidateWinners.py:

"details": {
        "cause": "An error occurred while executing the state 'Notify Winners' (entered at the event id #21). The JSONPath '$.sns' specified for the field 'Message.$' could not be found in the input '{\"body\": {\"num_of_winners\": 1, \"winner_details\": [{\"lottery_serial\": 8, \"employee_id\": \"008\", \"employee_name\": \"Paul\", \"employee_entry_date\": \"20190924\"}]}, \"status\": 0}'",
        "error": "States.Runtime"
    }


