### PR TITLE
add Lab13 to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ AWS 无服务器沉浸日动手实验（AWS 中国区）
   涉及到的服务有 AWS Lambda，EFS, EC2。
 
 * Lab13 借助 Lambda 函数导出 DynamoDB 表存储为 CSV 格式并存储到 S3 桶
-  利用 Lambda 函数扫描 DynamoDB 表并将其导出为 CSV 格式存储到 S3 桶。该方案可用于定时将 DynamoDB 表注入到 S3 数据湖或者导出到基于 CSV 格式的第三方分析服务。该方案采用无服务器的方式，无需 AWS Data Pipeline的创建或者 EMR群集以及Hive external table的创建和维护。
+  利用 Lambda 函数扫描 DynamoDB 表并将其导出为 CSV 格式存储到 S3 桶。该方案可用于定时将 DynamoDB 表注入到 S3 数据湖或者导出到基于 CSV 格式的第三方分析服务。该方案采用无服务器的方式，无需 AWS Data Pipeline的创建或者 EMR 群集以及 Hive external table 的创建和维护。
   涉及到的服务有 AWS Lambda，DynamoDB, S3。
 
 * Others Labs  

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ AWS 无服务器沉浸日动手实验（AWS 中国区）
   Lambda 函数通过 EFS 文件系统挂载大文件，实现机器学习推理场景。同时，借助 Provisioned Concurrency 特性，去除函数冷启动，极大提升推理响应时间。  
   涉及到的服务有 AWS Lambda，EFS, EC2。
 
+* Lab13 借助 Lambda 函数导出 DynamoDB 表存储为 CSV 格式并存储到 S3 桶
+  利用 Lambda 函数扫描 DynamoDB 表并将其导出为 CSV 格式存储到 S3 桶  
+  涉及到的服务有 AWS Lambda，DynamoDB, S3。
+
 * Others Labs  
   与 Lab1 采用类似的无服务器架构，创建您的第一个 AWS LAMBDA 函数，创建 Serverless 架构的调查问卷表单，通过流量转移安全部署 AWS LAMBDA 函数。  
   利用 Lambda 做 Redshift 数据注入。  

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ AWS 无服务器沉浸日动手实验（AWS 中国区）
   涉及到的服务有 AWS Lambda，EFS, EC2。
 
 * Lab13 借助 Lambda 函数导出 DynamoDB 表存储为 CSV 格式并存储到 S3 桶
-  利用 Lambda 函数扫描 DynamoDB 表并将其导出为 CSV 格式存储到 S3 桶  
+  利用 Lambda 函数扫描 DynamoDB 表并将其导出为 CSV 格式存储到 S3 桶。该方案可用于定时将 DynamoDB 表注入到 S3 数据湖或者导出到基于 CSV 格式的第三方分析服务。该方案采用无服务器的方式，无需 AWS Data Pipeline的创建或者 EMR群集以及Hive external table的创建和维护。
   涉及到的服务有 AWS Lambda，DynamoDB, S3。
 
 * Others Labs  


### PR DESCRIPTION
Update the README.md at root repository to guide customer to Lab13

本实验演示了如何使用 DynamoDB API和Lambda 扫描DynamoDB表并将其导出为CSV格式

官方方法是利用[AWS Data Pipeline](https://docs.aws.amazon.com/datapipeline/latest/DeveloperGuide/dp-template-exportddbtos3.html)，但是AWS Data Pipeline在北京区域和宁夏区域均没有发布。 使用EMR群集将数据导出到Hive table并转换为CSV格式的方式涉及到EMR群集以及Hive external table的创建和维护。
