### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/Lab13-Dump-DynamoDB-into-CSV-Stored-in-S3/serverless.yml
+++ b/Lab13-Dump-DynamoDB-into-CSV-Stored-in-S3/serverless.yml
@@ -21,7 +21,7 @@ service: ddb2csv-lambda # NOTE: update this with your service name
 
 provider:
   name: aws
-  runtime: nodejs10.x
+  runtime: nodejs14.x
   memorySize: 512
   timeout: 600
   stage: ${opt:stage, 'dev'} # Set the default stage used. Default is dev
@@ -36,7 +36,7 @@ layers:
     name: ${self:service}-ddb2csv-lambda-layer    # optional, Deployed Lambda layer name
     description: dynamodb-marshaler-2.0.0+ papaparse-4.1.4+  # optional, Description to publish to AWS
     compatibleRuntimes:                         # optional, a list of runtimes this layer is compatible with
-      - nodejs10.x
+      - nodejs14.x
     licenseInfo: MIT License                    # optional, a string specifying license information.  TODO: Update to your preferred license.
     allowedAccounts:                            # optional, a list of AWS account IDs allowed to access this layer. * for all. TODO: Update to your preferred accounts.
       - '*'

--- a/Lab7-WechatPush/code/sns2wechat/template.yaml
+++ b/Lab7-WechatPush/code/sns2wechat/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: 'AWS::Serverless::Function'
     Properties:
       Handler: sns2wechatinlambda/index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Description: ''
       MemorySize: 128
       Timeout: 15


### PR DESCRIPTION
CloudFormation templates in aws-serverless-workshop-greater-china-region have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.